### PR TITLE
Improve the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # C/C++ Dog Snippet
+
 This extension for Visual Studio Code adds snippets for C/C++.
 
 ## Installation
@@ -9,11 +10,65 @@ This extension for Visual Studio Code adds snippets for C/C++.
 4. Type `ext install` or just simply select `Install Extension`
 5. Choose the extension - C/C++ Dog Snippets
 
-
 ## Usage
+
 C/C++ Snippets Pro use Tab to change one position to another
 
+## Snippets
+
+### C Snippets
+
+| Snippet      | Description                      |
+| ------------ | -------------------------------- |
+| `#def`       | snippet for #define              |
+| `#ifdef`     | snippet for #if                  |
+| `#ifndef`    | snippet for #ifndef              |
+| `#inc`       | snippet for #include             |
+| `case`       | snippet for case (...)           |
+| `do`         | snippet for a do...while loop    |
+| `else`       | snippet for else                 |
+| `else if`    | snippet for else-if              |
+| `enum`       | snippet for an enum declaration  |
+| `fileheader` | snippet for a file header        |
+| `for`        | snippet for a for loop           |
+| `if`         | snippet for an if statement      |
+| `main`       | snippet for a main function      |
+| `struct`     | snippet for a struct declaration |
+| `switch`     | snippet for a switch statement   |
+| `union`      | snippet for a union declaration  |
+| `while`      | snippet for a while loop         |
+
+### C++ Snippets
+
+| Snippet         | Description                             |
+| --------------- | --------------------------------------- |
+| `#def`          | snippet for #def                        |
+| `#ifdef`        | snippet for #if                         |
+| `#ifndef`       | snippet for #ifndef                     |
+| `#inc`          | snippet for #include                    |
+| `case`          | snippet for case (...)                  |
+| `class`         | snippet for a class declaration         |
+| `class inherit` | snippet for a class-inherit declaration |
+| `do`            | snippet for a do...while loop           |
+| `else`          | snippet for else                        |
+| `else if`       | snippet for else-if                     |
+| `enum`          | snippet for an enum declaration         |
+| `fileheader`    | snippet for a file header               |
+| `for`           | snippet for a for loop                  |
+| `foreach`       | snippet for a for-auto loop             |
+| `if`            | snippet for an if statement             |
+| `main`          | snippet for a main function declaration |
+| `namespace`     | undefined                               |
+| `struct`        | snippet for a struct declaration        |
+| `switch`        | snippet for a switch statement          |
+| `template`      | snippet for a template                  |
+| `try`           | snippet for a try-catch block           |
+| `union`         | snippet for a union declaration         |
+| `using`         | snippet for using namespace             |
+| `while`         | snippet for a while loop                |
+
 ## Recommendations
+
 In order to give you a perfect plugin experience and avoid conflict with C/C++ Microsoft edition's snippet,
 I recommend you turn off C/C++ Microsoft edition's snippet. Details can be find in the below.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# C/C++ Dog Snippet
+# C/C++ Snippets Pro
 
 This extension for Visual Studio Code adds snippets for C/C++.
 
@@ -8,7 +8,7 @@ This extension for Visual Studio Code adds snippets for C/C++.
 2. Launch VS Code
 3. From the command palette `Ctrl`+`Shift`+`P` (Windows, Linux) or `Cmd`+`Shift`+`P` (OSX)
 4. Type `ext install` or just simply select `Install Extension`
-5. Choose the extension - C/C++ Dog Snippets
+5. Choose the extension - C/C++ Snippets Pro
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -1,35 +1,35 @@
 {
-    "name": "Snippets",
-    "publisher": "2211896472",
-    "displayName": "C/C++ Snippets Pro",
-    "description": "Code snippets for C/C++",
-    "version": "0.1.37",
-    "engines": {
-		"vscode": "^0.10.1"
-	},
-    "categories": [
-        "Snippets"
-    ],
-    "contributes": {
-		"snippets": [
-			{
-			"language": "c",
-			"path": "./snippets/c.json"
-			},
-			{
-			"language": "cpp",
-			"path": "./snippets/cpp.json"
-			}
-		]
-	},
-    "galleryBanner": { 
-        "color": "#E6E0EA", 
-        "theme": "dark" 
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/kkonghao/snippet-dog"
-    },
-    "icon": "images/cpp.png",
-    "license": "Check in License in the root folder"
+  "name": "snippets",
+  "publisher": "2211896472",
+  "displayName": "C/C++ Snippets Pro",
+  "description": "Code snippets for C/C++",
+  "version": "0.1.37",
+  "engines": {
+    "vscode": "^0.10.1"
+  },
+  "categories": [
+    "Snippets"
+  ],
+  "contributes": {
+    "snippets": [
+      {
+        "language": "c",
+        "path": "./snippets/c.json"
+      },
+      {
+        "language": "cpp",
+        "path": "./snippets/cpp.json"
+      }
+    ]
+  },
+  "galleryBanner": {
+    "color": "#E6E0EA",
+    "theme": "dark"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kkonghao/snippet-dog"
+  },
+  "icon": "images/cpp.png",
+  "license": "Check in License in the root folder"
 }

--- a/snippets/c.json
+++ b/snippets/c.json
@@ -1,195 +1,133 @@
-{	
-	"for": {
-		"prefix": "for",
-		"body": 
-		[
-			"for (int ${1} = ${2:0}; ${1} < ${3:length}; ${1}++)",
-			"{",
-			"\t$0",
-			"}\n"
-		],
-		"description": "Code snippet for 'for' loop"
-	},
+{
+  "for": {
+    "prefix": "for",
+    "body": ["for (int ${1} = ${2:0}; ${1} < ${3:length}; ${1}++)", "{", "\t$0", "}\n"],
+    "description": "snippet for a for loop"
+  },
 
-	"do": {
-		"prefix": "do",
-		"body": 
-		[
-			"do",
-			"{",
-			"\t$0",
-			"} while($1);\n"
-		],
-		"description": "Code snippet for do...while loop"
-	},
-	
-	"while": {
-		"prefix": "while",
-		"body": [
-			"while ($1)",
-			"{",
-			"\t$0",
-			"}\n"
-		],
-		"description": ""
-	},
+  "do": {
+    "prefix": "do",
+    "body": ["do", "{", "\t$0", "} while($1);\n"],
+    "description": "snippet for a do...while loop"
+  },
 
-	"if": {
-		"prefix": "if",
-		"body": [
-			"if ($1)",
-			"{",
-			"\t$0",
-			"}"
-		],
-		"description": "Code snippet for if"
-	},
+  "while": {
+    "prefix": "while",
+    "body": ["while ($1)", "{", "\t$0", "}\n"],
+    "description": "snippet for a while loop"
+  },
 
-	"else": {
-		"prefix": "else",
-		"body": [
-			"else",
-			"{",
-			"\t$0",
-			"}\n"
-		],
-		"description": "Code snippet for else"
-	},
-	"else if": {
-		"prefix": "else if",
-		"body": [
-			"else if ($1)",
-			"{",
-			"\t$0",
-			"}"
-		],
-		"description": "snippet for else-if  "
-	},
-	"enum": {
-		"prefix": "enum",
-		"body": [
-			"enum $1",
-			"{",
-			"\t$0",
-			"};\n"
-		],
-		"description": "snippet for enum"
-	},
+  "if": {
+    "prefix": "if",
+    "body": ["if ($1)", "{", "\t$0", "}"],
+    "description": "snippet for an if statement"
+  },
 
-	"#ifndef": {
-		"prefix": "#ifndef",
-		"body": [
-			"#ifndef __${TM_FILENAME_BASE/(.*)/${1:/upcase}/}__H__",
-			"#define __${TM_FILENAME_BASE/(.*)/${1:/upcase}/}__H__",
-			"$0",
-			"#endif  //!__${TM_FILENAME_BASE/(.*)/${1:/upcase}/}__H__"
-		],
-		"description": "snippet for #ifndef"
-	},
+  "else": {
+    "prefix": "else",
+    "body": ["else", "{", "\t$0", "}\n"],
+    "description": "snippet for else"
+  },
+  "else if": {
+    "prefix": "else if",
+    "body": ["else if ($1)", "{", "\t$0", "}"],
+    "description": "snippet for else-if"
+  },
+  "enum": {
+    "prefix": "enum",
+    "body": ["enum $1", "{", "\t$0", "};\n"],
+    "description": "snippet for an enum declaration"
+  },
 
+  "#ifndef": {
+    "prefix": "#ifndef",
+    "body": [
+      "#ifndef __${TM_FILENAME_BASE/(.*)/${1:/upcase}/}__H__",
+      "#define __${TM_FILENAME_BASE/(.*)/${1:/upcase}/}__H__",
+      "$0",
+      "#endif  //!__${TM_FILENAME_BASE/(.*)/${1:/upcase}/}__H__"
+    ],
+    "description": "snippet for #ifndef"
+  },
 
-	"#ifdef": {
-		"prefix": "#ifdef",
-		"body": [
-			"#ifdef  $1",
-			"$0",
-			"#endif  //$1"
-		],
-		"description": "snippet for #if"
-	},
+  "#ifdef": {
+    "prefix": "#ifdef",
+    "body": ["#ifdef  $1", "$0", "#endif  //$1"],
+    "description": "snippet for #if"
+  },
 
-	"struct": {
-		"prefix": "struct",
-		"body": [
-			"struct $1",
-			"{",
-			"\t$0",
-			"};"
-		],
-		"description": "snippet for struct"
-	},
-	"switch": {
-		"prefix": "switch",
-		"body": [
-			"switch ($1)",
-			"{",
-			"  case $2:",
-			"\t$0",
-			"\tbreak;",
-			"\n",
-			"\n",
-			"  default:",
-			"\tbreak;",
-			"}"
-		],
+  "struct": {
+    "prefix": "struct",
+    "body": ["struct $1", "{", "\t$0", "};"],
+    "description": "snippet for a struct declaration"
+  },
+  "switch": {
+    "prefix": "switch",
+    "body": [
+      "switch ($1)",
+      "{",
+      "  case $2:",
+      "\t$0",
+      "\tbreak;",
+      "\n",
+      "\n",
+      "  default:",
+      "\tbreak;",
+      "}"
+    ],
 
-		"description": "snippet for switch  "
-	},
-	"case":{
-		"prefix":"case",
-		"body":[
-			"  case $1:",
-			"\t$0",
-			"\tbreak;"
-		],
-		"description": "snippet for case (...)"
-	},
+    "description": "snippet for a switch statement"
+  },
+  "case": {
+    "prefix": "case",
+    "body": ["  case $1:", "\t$0", "\tbreak;"],
+    "description": "snippet for case (...)"
+  },
 
-	"union": {
-		"prefix": "union",
-		"body": [
-			"union $1",
-			"{",
-			"\t$0",
-			"}\n;"
-		],
-		"description": "snippet for union"
-	},
+  "union": {
+    "prefix": "union",
+    "body": ["union $1", "{", "\t$0", "}\n;"],
+    "description": "snippet for a union declaration"
+  },
 
-	"#inc": {
-		"prefix": "#inc",
-		"body": [
-			"#include "
-		],
-		"description": ""
-	},
-	
+  "#inc": {
+    "prefix": "#inc",
+    "body": ["#include "],
+    "description": "snippet for #include"
+  },
 
-	"#def": {
-		"prefix": "#def",
-		"body": [
-			"#define  $1  $2",
-			"$0"
-			],
-		"description": "snippet for #define"
-	},
-	  "main": {
-        "prefix": [ "main" ],
-        "body": [
-			"int\tmain(int argc, char **argv)",
-			"{",
-            "\t$0",
-            
-			"\n",
-			"\tsystem(\"pause\");",
-			"\treturn 0;",
-			"}\n"
-        ],
-        "description": "create a main function"
-	},
-	
-"fileheader": {
-		"prefix": "fileheader",
-		"body": [
-			"/**",
-			"**********************************************************************************************************************************************************************************************************************************",
-			"* @file:\t$TM_FILENAME",
-			"* @author:\t$1",
-			"* @date:\t$CURRENT_YEAR年$CURRENT_MONTH月$CURRENT_DATE日 $CURRENT_HOUR:$CURRENT_MINUTE:$CURRENT_SECOND $CURRENT_DAY_NAME",
-			"* @brief:\t$2",
-			"**********************************************************************************************************************************************************************************************************************************",
-			"**/"
-		],
-		"description": "create a file header"
-	}
+  "#def": {
+    "prefix": "#def",
+    "body": ["#define  $1  $2", "$0"],
+    "description": "snippet for #define"
+  },
+  "main": {
+    "prefix": ["main"],
+    "body": [
+      "int\tmain(int argc, char **argv)",
+      "{",
+      "\t$0",
+
+      "\n",
+      "\tsystem(\"pause\");",
+      "\treturn 0;",
+      "}\n"
+    ],
+    "description": "snippet for a main function"
+  },
+
+  "fileheader": {
+    "prefix": "fileheader",
+    "body": [
+      "/**",
+      "**********************************************************************************************************************************************************************************************************************************",
+      "* @file:\t$TM_FILENAME",
+      "* @author:\t$1",
+      "* @date:\t$CURRENT_YEAR年$CURRENT_MONTH月$CURRENT_DATE日 $CURRENT_HOUR:$CURRENT_MINUTE:$CURRENT_SECOND $CURRENT_DAY_NAME",
+      "* @brief:\t$2",
+      "**********************************************************************************************************************************************************************************************************************************",
+      "**/"
+    ],
+    "description": "snippet for a file header"
+  }
 }

--- a/snippets/cpp.json
+++ b/snippets/cpp.json
@@ -1,276 +1,178 @@
 {
-	"#inc": {
-		"prefix": "#inc",
-		"body": [
-			"#include "
-		],
-		"description": ""
-	},
+  "#inc": {
+    "prefix": "#inc",
+    "body": ["#include "],
+    "description": "snippet for #include"
+  },
 
-	"using":{
-		"prefix":"using",
-		"body":[
-			"using namespace $0"
-		],
-		"description": "snippet for using namespace"
-	},
+  "using": {
+    "prefix": "using",
+    "body": ["using namespace $0"],
+    "description": "snippet for using namespace"
+  },
 
-	"for": {
-		"prefix": "for",
-		"body": [
-			"for (int ${1} = ${2:0}; ${1} < ${3:length}; ${1}++)",
-			"{",
-			"\t$0",
-			"}\n"
-		],
-		"description": "snippet for 'for' loop"
-	},
-	
+  "for": {
+    "prefix": "for",
+    "body": ["for (int ${1} = ${2:0}; ${1} < ${3:length}; ${1}++)", "{", "\t$0", "}\n"],
+    "description": "snippet for a for loop"
+  },
 
-	"foreach":{
-		"prefix":"fore",
-		"body":[
-			"for (auto &$1 : $2)",
-			"{",
-			"\t$0",
-			"}\n"
-		],
-		"description": "snippet for 'for' auto"
-	},
-	
-	"do": {
-		"prefix": "do",
-		"body": 
-		[
-			"do",
-			"{",
-			"\t$0",
-			"} while($1);\n"
-		],
-		"description": "snippet for do...while loop"
-	},
+  "foreach": {
+    "prefix": "fore",
+    "body": ["for (auto &$1 : $2)", "{", "\t$0", "}\n"],
+    "description": "snippet for a for-auto loop"
+  },
 
-	"while": {
-		"prefix": "while",
-		"body": [
-			"while ($1)",
-			"{",
-			"\t$0",
-			"}\n"
-		],
-		"description": ""
-	},
+  "do": {
+    "prefix": "do",
+    "body": ["do", "{", "\t$0", "} while($1);\n"],
+    "description": "snippet for a do...while loop"
+  },
 
-	"if": {
-		"prefix": "if",
-		"body": [
-			"if ($1)",
-			"{",
-			"\t$0",
-			"}"
-		],
-		"description": "snippet for if  "
-	},
+  "while": {
+    "prefix": "while",
+    "body": ["while ($1)", "{", "\t$0", "}\n"],
+    "description": "snippet for a while loop"
+  },
 
-	"else": {
-		"prefix": "else",
-		"body": [
-			"else",
-			"{",
-			"\t$0",
-			"}\n"
-		],
-		"description": "snippet for else"
-	},
+  "if": {
+    "prefix": "if",
+    "body": ["if ($1)", "{", "\t$0", "}"],
+    "description": "snippet for an if statement"
+  },
 
-	"else if": {
-		"prefix": "else if",
-		"body": [
-			"else if ($1)",
-			"{",
-			"\t$0",
-			"}"
-		],
-		"description": "snippet for else-if"
-	},
+  "else": {
+    "prefix": "else",
+    "body": ["else", "{", "\t$0", "}\n"],
+    "description": "snippet for else"
+  },
 
-	"enum": {
-		"prefix": "enum",
-		"body": [
-			"enum $1",
-			"{",
-			"\t$0",
-			"};\n"
-		],
-		"description": "snippet for enum"
-	},
+  "else if": {
+    "prefix": "else if",
+    "body": ["else if ($1)", "{", "\t$0", "}"],
+    "description": "snippet for else-if"
+  },
 
-	"class": {
-		"prefix": "class",
-		"body": [
-			"class $0",
-			"{",	
-			"",
-			"};\n"
-		],
-		"description": "snippet for class"
-	},
+  "enum": {
+    "prefix": "enum",
+    "body": ["enum $1", "{", "\t$0", "};\n"],
+    "description": "snippet for an enum declaration"
+  },
 
-	"class inherit": {
-		"prefix": "classi",
-		"body": [
-			"class $1 :public $0",
-			"{",	
-			"",
-			"};\n"
-		],
-		"description": "snippet for class inherit"
-	},
+  "class": {
+    "prefix": "class",
+    "body": ["class $0", "{", "", "};\n"],
+    "description": "snippet for a class declaration"
+  },
 
+  "class inherit": {
+    "prefix": "classi",
+    "body": ["class $1 :public $0", "{", "", "};\n"],
+    "description": "snippet for a class-inherit declaration"
+  },
 
-	"namespace": {
-		"prefix": "namespace",
-		"body": [
-			"namespace $1",
-			"{",
-			"\t$0",
-			"}//$1\n"
-		]
-	},
+  "namespace": {
+    "prefix": "namespace",
+    "body": ["namespace $1", "{", "\t$0", "}//$1\n"]
+  },
 
-	
-	"#ifndef": {
-		"prefix": "#ifndef",
-		"body": [
-			"#ifndef __${TM_FILENAME_BASE/(.*)/${1:/upcase}/}__H__",
-			"#define __${TM_FILENAME_BASE/(.*)/${1:/upcase}/}__H__",
-			"$0",
-			"#endif  //!__${TM_FILENAME_BASE/(.*)/${1:/upcase}/}__H__"
-		],
-		"description": "snippet for #ifndef"
-	},
+  "#ifndef": {
+    "prefix": "#ifndef",
+    "body": [
+      "#ifndef __${TM_FILENAME_BASE/(.*)/${1:/upcase}/}__H__",
+      "#define __${TM_FILENAME_BASE/(.*)/${1:/upcase}/}__H__",
+      "$0",
+      "#endif  //!__${TM_FILENAME_BASE/(.*)/${1:/upcase}/}__H__"
+    ],
+    "description": "snippet for #ifndef"
+  },
 
+  "#ifdef": {
+    "prefix": "#ifdef",
+    "body": ["#ifdef  ${1}", "$0", "#endif  //$1"],
+    "description": "snippet for #if"
+  },
 
-	"#ifdef": {
-		"prefix": "#ifdef",
-		"body": [
-			"#ifdef  ${1}",
-			"$0",
-			"#endif  //$1"
-		],
-		"description": "snippet for #if"
-	},
+  "struct": {
+    "prefix": "struct",
+    "body": ["struct $1", "{", "\t$0", "};\n"],
+    "description": "snippet for a struct declaration"
+  },
 
-	"struct": {
-		"prefix": "struct",
-		"body": [
-			"struct $1",
-			"{",
-			"\t$0",
-			"};\n"
-		],
-		"description": "snippet for struct"
-	},
+  "switch": {
+    "prefix": "switch",
+    "body": [
+      "switch ($1)",
+      "{",
+      "  case $2:",
+      "\t$0",
+      "\tbreak;",
+      "\n",
+      "\n",
+      "  default:",
+      "\tbreak;",
+      "}"
+    ],
+    "description": "snippet for a switch statement"
+  },
 
-	"switch": {
-		"prefix": "switch",
-		"body": [
-			"switch ($1)",
-			"{",
-			"  case $2:",
-			"\t$0",
-			"\tbreak;",
-			"\n",
-			"\n",
-			"  default:",
-			"\tbreak;",
-			"}"
-		],
-		"description": "snippet for switch  "
-	},
+  "case": {
+    "prefix": "case",
+    "body": ["  case $1:", "\t$0", "\tbreak;"],
+    "description": "snippet for case (...)"
+  },
 
-	"case":{
-		"prefix":"case",
-		"body":[
-			"  case $1:",
-			"\t$0",
-			"\tbreak;"
-		],
-		"description": "snippet for case (...)"
-	},
+  "try": {
+    "prefix": "try",
+    "body": ["try", "{", "\t$1", "}", "catch (const std::exception& $2)", "{", "\t$0", "}\n"],
+    "description": "snippet for a try-catch block"
+  },
 
-	"try": {
-		"prefix": "try",
-		"body": [
-			"try",
-			"{",
-			"\t$1",
-			"}",
-			"catch (const std::exception& $2)",
-			"{",
-			"\t$0",
-			"}\n"
-		],
-		"description": "snippet for try catch"
-	},
-	
-	"union": {
-		"prefix": "union",
-		"body": 
-		[
-			"union $1",
-			"{",
-			"\t$0",
-			"};\n"
-		],
-		"description": "snippet for union"
-	},
+  "union": {
+    "prefix": "union",
+    "body": ["union $1", "{", "\t$0", "};\n"],
+    "description": "snippet for a union declaration"
+  },
 
-	"#def": {
-		"prefix": "#def",
-		"body": [
-			"#define  $1  $2\n"
-			],
-		"description": ""
-	},
+  "#def": {
+    "prefix": "#def",
+    "body": ["#define  $1  $2\n"],
+    "description": "snippet for #def"
+  },
 
-	"main": {
-        "prefix": "main",
-        "body": [
-			"int\tmain(int argc, char **argv)",
-			"{",
-            "\t$0",
-            
-			"\n",
-			"\tsystem(\"pause\");",
-			"\treturn 0;",
-			"}\n"
-        ],
-        "description": "create a main function"
-	},
+  "main": {
+    "prefix": "main",
+    "body": [
+      "int\tmain(int argc, char **argv)",
+      "{",
+      "\t$0",
 
-	"fileheader": {
-		"prefix": "fileheader",
-		"body": [
-			"/**",
-			"**********************************************************************************************************************************************************************************************************************************",
-			"* @file:\t$TM_FILENAME",
-			"* @author:\t$1",
-			"* @date:\t$CURRENT_YEAR年$CURRENT_MONTH月$CURRENT_DATE日 $CURRENT_HOUR:$CURRENT_MINUTE:$CURRENT_SECOND $CURRENT_DAY_NAME",
-			"* @brief:\t$2",
-			"**********************************************************************************************************************************************************************************************************************************",
-			"**/"
-		],
-		"description": "create a file header"
-	},
+      "\n",
+      "\tsystem(\"pause\");",
+      "\treturn 0;",
+      "}\n"
+    ],
+    "description": "snippet for a main function declaration"
+  },
 
+  "fileheader": {
+    "prefix": "fileheader",
+    "body": [
+      "/**",
+      "**********************************************************************************************************************************************************************************************************************************",
+      "* @file:\t$TM_FILENAME",
+      "* @author:\t$1",
+      "* @date:\t$CURRENT_YEAR年$CURRENT_MONTH月$CURRENT_DATE日 $CURRENT_HOUR:$CURRENT_MINUTE:$CURRENT_SECOND $CURRENT_DAY_NAME",
+      "* @brief:\t$2",
+      "**********************************************************************************************************************************************************************************************************************************",
+      "**/"
+    ],
+    "description": "snippet for a file header"
+  },
 
-	"template":{
-		"prefix":"tem",
-		"body":[
-			"template <typename $0>"
-		],
-		"description": "template snippet"
-	}
+  "template": {
+    "prefix": "tem",
+    "body": ["template <typename $0>"],
+    "description": "snippet for a template"
+  }
 }
-


### PR DESCRIPTION
Hey, I noticed that the readme doesn't have a list of all the snippets so I added lists for each language. I also changed the wording of a couple of the descriptions just to keep it consistent.

Also, I noticed that the readme uses the name of the repo but the name in the VS Code marketplace is "C/C++ Snippets Pro" so I changed the readme to match. If you don't want this then you can just unstage that last commit.

I hope this helps, but feel free to ignore this PR